### PR TITLE
Change "Cliffening" to "Triple Halvening"

### DIFF
--- a/faqs/what-is-the-cliffening.md
+++ b/faqs/what-is-the-cliffening.md
@@ -1,5 +1,5 @@
 ---
-title: What is "The Cliffening"?
+title: What is "The Triple Halvening"?
 weight: 7.0
 attribution:
   -
@@ -10,10 +10,10 @@ attribution:
     link: https://www.reddit.com/user/decibels42
 ---
 
-"The Cliffening" is the community name given to the large drop in ETH issuance that will occur once "The Merge" occurs and Ethereum is fully upgraded to the proof-of-stake (PoS) consensus algorithm. “The Cliffening” is a play on the popular Bitcoin phrase, “The Halvening”. While Bitcoin halves its issuance rate every 4 years, Ethereum will see its issuance rate reduced by roughly 90% at the time of "The Merge". That's equivalent to *3 Bitcoin "Halvenings" happening at once! Ethereum will experience an issuance reduction in an instant what will take an additional 12 years to be matched on Bitcoin's network.
+"The Triple Halvening" is the community name given to the large drop in ETH issuance that will occur once "The Merge" occurs and Ethereum is fully upgraded to the proof-of-stake (PoS) consensus algorithm. “The Triple Halvening” is a play on Bitcoin's “Halvening”. While Bitcoin halves its issuance rate every 4 years, Ethereum will see its issuance rate reduced by roughly 90% at the time of "The Merge". That's equivalent to *3 Bitcoin "Halvenings" happening at once! Ethereum will experience an issuance reduction in an instant what will take an additional 12 years to be matched on Bitcoin's network.
 
 Under the current proof-of-work (PoW) model Ethereum issues roughly [13,500 ETH per day](https://etherscan.io/chart/blockreward) — an annual issuance of about `4.3%` of the total ETH supply. However, the PoS issuance model is determined based on how much ETH is actively being staked on the network. [Current projections](https://i.imgur.com/8u5zY4l.jpg) predict a drop to between a `0.3%` to `0.4%` issuance rate when "The Merge" occurs.
 
 For comparison, Bitcoin currently issues 900 BTC per day — an annual issuance of about `1.7%` of the total BTC supply. The next two "Halvenings" will reduce Bitcoin's issuance to approximately `0.8%` in 2024 and `0.4%` in 2028. With Ethereum’s expected drop in issuance after "The Merge" to between `0.3% - 0.4%` it will not be until 2028 that Bitcoin's issuance is again within range of Ethereum's.
 
-When "The Cliffening" is combined with the `BASEFEE` burn mechanism of [EIP-1559](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md) (which will be included in the Ethereum 1.0 PoW London hard fork during the summer of 2021) it is projected that Ethereum's issuance will actually become deflationary during periods of high user activity.
+When "The Triple Halvening" is combined with the `BASEFEE` burn mechanism of [EIP-1559](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1559.md) (live as of August 2021) it is projected that Ethereum's issuance will actually become deflationary during periods of high user activity.


### PR DESCRIPTION
Triple Halvening has pretty much become the standard nomenclature, as trendy as decibels and I thought Cliffening was ;)